### PR TITLE
Vulnerability fix : Bump hadoop version to resolve log4j vulnerability

### DIFF
--- a/confluent-kafka-plugins/pom.xml
+++ b/confluent-kafka-plugins/pom.xml
@@ -224,7 +224,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.5.1</version>
         <configuration>
           <instructions>
             <_exportcontents>
@@ -255,8 +255,8 @@
         <version>1.1.0</version>
         <configuration>
           <cdapArtifacts>
-            <parent>system:cdap-data-pipeline[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
-            <parent>system:cdap-data-streams[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-pipeline[6.8.0,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-streams[6.8.0,7.0.0-SNAPSHOT)</parent>
           </cdapArtifacts>
         </configuration>
         <executions>

--- a/confluent-kafka-plugins/src/test/java/io/cdap/plugin/confluent/integration/streaming/sink/ConfluentStreamingSinkTest.java
+++ b/confluent-kafka-plugins/src/test/java/io/cdap/plugin/confluent/integration/streaming/sink/ConfluentStreamingSinkTest.java
@@ -279,7 +279,7 @@ public class ConfluentStreamingSinkTest extends ConfluentStreamingTestBase {
     throws Exception {
     List<ConsumerRecord<K, V>> result = new ArrayList<>();
     Stopwatch stopwatch = new Stopwatch();
-    while (result.size() < expectedMessages && stopwatch.elapsed(TimeUnit.SECONDS) < 10) {
+    while (result.size() < expectedMessages && stopwatch.elapsedTime(TimeUnit.SECONDS) < 10) {
       ConsumerRecords<K, V> records = consumer.poll(Duration.ofMillis(100));
       for (ConsumerRecord<K, V> record : records) {
         result.add(record);

--- a/pom.xml
+++ b/pom.xml
@@ -87,15 +87,15 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>6.1.1</cdap.version>
-    <cdap.plugin.version>2.3.5</cdap.plugin.version>
+    <cdap.version>6.8.0</cdap.version>
+    <cdap.plugin.version>2.10.0</cdap.plugin.version>
     <spark1.version>1.6.1</spark1.version>
     <spark2.version>2.3.0</spark2.version>
     <widgets.dir>widgets</widgets.dir>
     <docs.dir>docs</docs.dir>
     <kafka8.version>0.8.2.2</kafka8.version>
     <kafka10.version>0.10.2.0</kafka10.version>
-    <hadoop.version>2.3.0</hadoop.version>
+    <hadoop.version>2.10.2</hadoop.version>
     <netty.version>4.1.16.Final</netty.version>
     <netty-http.version>1.3.0</netty-http.version>
     <avro.version>1.8.2</avro.version>


### PR DESCRIPTION
Change Description

- Fixed security vulnerability for log4j dependency

Changes:

- Bumped cdap, hadoop, hydrator plugins version.

Verification

- Verified version override using mvn dependency:tree
- Build successful.Few unit tests failed as they required appropriate system properties.